### PR TITLE
[#13] Pinned flower model dependencies

### DIFF
--- a/mlflow/sklearn/wine/conda.yaml
+++ b/mlflow/sklearn/wine/conda.yaml
@@ -8,5 +8,5 @@ dependencies:
   - scikit-learn=0.19.1
   - pip:
     - mlflow==1.0.0
-    - cloudpickle
+    - cloudpickle==1.3.0
     - azure-storage==0.36.0

--- a/mlflow/tensorflow/flower_classifier/conda.yaml
+++ b/mlflow/tensorflow/flower_classifier/conda.yaml
@@ -3,11 +3,11 @@ channels:
   - defaults
   - anaconda
 dependencies:
-  - python==3.7
-  - pandas
-  - scikit-learn
-  - tensorflow-gpu
-  - keras
+  - python=3.7
+  - pandas=1.0.1
+  - scikit-learn=0.22.1
+  - tensorflow-gpu=1.15.0
+  - keras=2.2.4
   - pip:
-    - mlflow>=1.0
-    - pillow
+    - mlflow==1.5.0
+    - pillow==7.0.0


### PR DESCRIPTION
After TensorFlow upgrade to the 2.0 version, we encountered the following error:
AttributeError: module 'tensorflow' has no attribute 'Session'.