### PR TITLE
[fix] Memory resources increased for `airflow-wine-from-yamls` packaging

### DIFF
--- a/mlflow/sklearn/wine/airflow/dag_from_yamls/dag_from_yamls.py
+++ b/mlflow/sklearn/wine/airflow/dag_from_yamls/dag_from_yamls.py
@@ -30,10 +30,10 @@ spec:
   resources:
     requests:
       cpu: 2
-      memory: 2Gi
+      memory: 2.5Gi
     limits:
       cpu: 2
-      memory: 2Gi
+      memory: 4Gi
 """)
 
 deployment_id, deployment = resource("""


### PR DESCRIPTION
Memory limit increase caused by eventually OOMkilled `step-packager` container process

```
Killed
error building at STEP "RUN conda env update --name=${ODAHU_CONDA_ENV_NAME} --file=conda.yaml": error while running runtime: exit status 137
```