### PR TITLE
[#462] Fix mlflow version for Wine

### DIFF
--- a/mlflow/sklearn/wine/conda.yaml
+++ b/mlflow/sklearn/wine/conda.yaml
@@ -8,4 +8,4 @@ dependencies:
   - pandas=0.25.3
   - scikit-learn=0.19.1
   - pip:
-    - mlflow=1.13
+    - mlflow==1.13

--- a/mlflow/sklearn/wine/conda.yaml
+++ b/mlflow/sklearn/wine/conda.yaml
@@ -8,4 +8,4 @@ dependencies:
   - pandas=0.25.3
   - scikit-learn=0.19.1
   - pip:
-    - mlflow
+    - mlflow=1.13


### PR DESCRIPTION
In 1.13.1 release (https://github.com/mlflow/mlflow/releases/tag/v1.13.1) mlflow changed the logic of generating `conda.yaml` file for SKLearn models. `scikit-learn` used to be Conda dependency, now it is pip dependency in a corresponding section of `conda.yaml`. Package from Conda also installs additional pre-built package `scipy`, but pip doesn't.

The bug for that is already open: https://github.com/mlflow/mlflow/issues/3955. So we just fix the version to be `1.13` with old proper logic.
```
channels:
- defaults
- conda-forge
dependencies:
- python=3.6.12
- pip
- pip:
  - mlflow
  - scikit-learn==0.19.1
  - cloudpickle==1.6.0
name: mlflow-env
```