### PR TITLE
[#456] Update examples to have `predictor` in deployment spec

### DIFF
--- a/mlflow/sklearn/wine/airflow/dag_from_yamls/dag_from_yamls.py
+++ b/mlflow/sklearn/wine/airflow/dag_from_yamls/dag_from_yamls.py
@@ -41,6 +41,7 @@ id: airflow-wine-from-yamls
 kind: ModelDeployment
 spec:
   image: "<fill-in>"
+  predictor: "odahu-ml-server"
   minReplicas: 1
 """)
 

--- a/mlflow/sklearn/wine/odahuflow/deployment.odahuflow.yaml
+++ b/mlflow/sklearn/wine/odahuflow/deployment.odahuflow.yaml
@@ -2,4 +2,5 @@ id: wine
 kind: ModelDeployment
 spec:
   image: "<fill-in>"
+  predictor: odahu-ml-server
   minReplicas: 1

--- a/mlflow/tensorflow/flower_classifier/odahuflow/deployment.odahuflow.yaml
+++ b/mlflow/tensorflow/flower_classifier/odahuflow/deployment.odahuflow.yaml
@@ -2,6 +2,7 @@ id: flower-classifier
 kind: ModelDeployment
 spec:
   image: "<fill-in>"
+  predictor: odahu-ml-server
   livenessProbeInitialDelay: 90
   readinessProbeInitialDelay: 90
   minReplicas: 1

--- a/mlflow/tensorflow/reuters_classifier/odahuflow/deployment.odahuflow.yaml
+++ b/mlflow/tensorflow/reuters_classifier/odahuflow/deployment.odahuflow.yaml
@@ -2,4 +2,5 @@ id: reuters-classifier
 kind: ModelDeployment
 spec:
   image: "<fill-in>"
+  predictor: odahu-ml-server
   minReplicas: 1


### PR DESCRIPTION
Update examples according to changes in https://github.com/odahu/odahu-flow/pull/477
