### PR TITLE
Rename "odahu-ml-server" predictor to just "odahu"

### DIFF
--- a/mlflow/sklearn/wine/airflow/dag_from_yamls/dag_from_yamls.py
+++ b/mlflow/sklearn/wine/airflow/dag_from_yamls/dag_from_yamls.py
@@ -41,7 +41,7 @@ id: airflow-wine-from-yamls
 kind: ModelDeployment
 spec:
   image: "<fill-in>"
-  predictor: "odahu-ml-server"
+  predictor: "odahu"
   minReplicas: 1
 """)
 

--- a/mlflow/sklearn/wine/odahuflow/deployment.odahuflow.yaml
+++ b/mlflow/sklearn/wine/odahuflow/deployment.odahuflow.yaml
@@ -2,5 +2,5 @@ id: wine
 kind: ModelDeployment
 spec:
   image: "<fill-in>"
-  predictor: odahu-ml-server
+  predictor: odahu
   minReplicas: 1

--- a/mlflow/tensorflow/flower_classifier/odahuflow/deployment.odahuflow.yaml
+++ b/mlflow/tensorflow/flower_classifier/odahuflow/deployment.odahuflow.yaml
@@ -2,7 +2,7 @@ id: flower-classifier
 kind: ModelDeployment
 spec:
   image: "<fill-in>"
-  predictor: odahu-ml-server
+  predictor: odahu
   livenessProbeInitialDelay: 90
   readinessProbeInitialDelay: 90
   minReplicas: 1

--- a/mlflow/tensorflow/reuters_classifier/odahuflow/deployment.odahuflow.yaml
+++ b/mlflow/tensorflow/reuters_classifier/odahuflow/deployment.odahuflow.yaml
@@ -2,5 +2,5 @@ id: reuters-classifier
 kind: ModelDeployment
 spec:
   image: "<fill-in>"
-  predictor: odahu-ml-server
+  predictor: odahu
   minReplicas: 1


### PR DESCRIPTION
Rename "odahu-ml-server" predictor to just "odahu".
As requested in odahu/odahu-docs#107